### PR TITLE
Update README and conceptual use for constructor parameter changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export type User = z.infer<typeof UserSchema>;
 
 export class UserModel extends BaseModel<User, typeof UserSchema> {
     constructor(initialData?: User) {
-        super(initialData || null, UserSchema);
+        super({ initialData: initialData || null, schema: UserSchema });
     }
 }
 ```
@@ -96,7 +96,13 @@ const myCustomFetcher: Fetcher = async (url, options) => {
 export class UserApiModels extends RestfulApiModel<User[], typeof UserSchema> {
     constructor() {
         // Assuming your API returns an array of users for the base endpoint
-        super('[https://api.yourapp.com](https://api.yourapp.com)', 'users', myCustomFetcher, z.array(UserSchema));
+        super({
+            baseUrl: 'https://api.yourapp.com',
+            endpoint: 'users',
+            fetcher: myCustomFetcher,
+            schema: z.array(UserSchema),
+            initialData: null // Or provide initial data if available
+        });
     }
 }
 ```

--- a/src/viewmodels/conceptual-use.md
+++ b/src/viewmodels/conceptual-use.md
@@ -44,10 +44,12 @@ Your custom model class will extend `RestfulApiModel` and be configured for a sp
 
 **Constructor Parameters:**
 
+The constructor accepts a single input object with the following properties:
 *   `baseUrl`: The base URL of your API (e.g., `https://api.example.com`).
 *   `endpoint`: The specific path for the resource (e.g., `users`, `profile`).
 *   `fetcher`: A function responsible for making the actual HTTP requests. This allows you to use `window.fetch`, a library like `axios`, or any custom fetching logic.
 *   `schema`: The Zod schema for validating the data (`TData`) this model handles.
+*   `initialData` (optional): Initial data for the model.
 
 **Fetcher Function Example:**
 
@@ -98,7 +100,13 @@ import { appFetcher } from '../utils/fetcher';
 
 export class UserCollectionApiModel extends RestfulApiModel<User[], z.ZodArray<typeof UserSchema>> {
   constructor() {
-    super('https://api.yourapp.com', 'users', appFetcher, z.array(UserSchema));
+    super({
+      baseUrl: 'https://api.yourapp.com',
+      endpoint: 'users',
+      fetcher: appFetcher,
+      schema: z.array(UserSchema),
+      initialData: null // Or an empty array [] if that's preferred for collections
+    });
   }
 
   // You can add custom methods here if needed, e.g.:
@@ -121,7 +129,13 @@ import { appFetcher } from '../utils/fetcher';
 export class UserProfileApiModel extends RestfulApiModel<UserProfile, typeof UserProfileSchema> {
   constructor(userId: string) {
     // Endpoint might be dynamic, e.g., users/{userId}/profile
-    super('https://api.yourapp.com', `users/${userId}/profile`, appFetcher, UserProfileSchema);
+    super({
+      baseUrl: 'https://api.yourapp.com',
+      endpoint: `users/${userId}/profile`,
+      fetcher: appFetcher,
+      schema: UserProfileSchema,
+      initialData: null
+    });
   }
 
   // Example: Custom method to update specific fields


### PR DESCRIPTION
I've updated README.md and src/viewmodels/conceptual-use.md to accurately reflect that BaseModel and RestfulApiModel constructors now accept parameters as a single input object.

- I modified constructor examples in README.md for BaseModel and RestfulApiModel.
- I updated constructor description and examples in src/viewmodels/conceptual-use.md for RestfulApiModel.