### PR TITLE
Fix: Ensure TypeScript declarations are correctly generated and bundled.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mvvm-core",
-  "version": "0.3.1",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mvvm-core",
-      "version": "0.3.1",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Festus Yeboah<festus.yeboah@hotmail.com>",
   "license": "MIT",
   "private": false,
-  "version": "0.3.7",
+  "version": "0.4.0",
   "type": "module",
   "files": [
     "dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,7 @@
     "moduleDetection": "force",
     "noEmit": false,
     "declaration": true,
-    // "declarationDir": "./dist",
-    "declarationMap": true,
-    "emitDeclarationOnly": false,
+    "emitDeclarationOnly": true,
     "outDir": "dist",
     /* Linting */
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import dts from "vite-plugin-dts";
 
 export default defineConfig({
   build: {
+    clearScreen: false,
     outDir: "dist", // Explicitly set outDir
     lib: {
       entry: "./src/index.ts",
@@ -11,5 +12,5 @@ export default defineConfig({
       fileName: "index",
     },
   },
-  plugins: [dts({ insertTypesEntry: true, outDir: "dist" })], // also specify for dts plugin
+  plugins: [dts({ insertTypesEntry: true, outDir: "dist", tsconfigPath: './tsconfig.json' })], // also specify for dts plugin
 });


### PR DESCRIPTION
This commit addresses an issue where TypeScript type information and autocompletion were not working correctly when using the published package.

Changes made:
- Modified `tsconfig.json`:
    - Set `compilerOptions.emitDeclarationOnly` to `true` to clarify `tsc`'s role in a Vite project.
    - Removed `compilerOptions.declarationDir` and `compilerOptions.declarationMap` as `vite-plugin-dts` handles declaration output.
- Updated `vite.config.ts`:
    - Added `build.clearScreen = false` for better visibility of build logs.
    - Explicitly provided `tsconfigPath: './tsconfig.json'` to the `vite-plugin-dts` configuration to ensure it uses the correct TypeScript configuration.
- Incremented the package version from `0.3.7` to `0.4.0`.

These changes ensure that `vite-plugin-dts` correctly generates and bundles the type declaration files (`.d.ts`) into the `dist` directory, making them available for consuming projects.