### PR TITLE
Fix: Improve TypeScript declaration generation using rollupTypes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mvvm-core",
-  "version": "0.3.7",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mvvm-core",
-      "version": "0.3.7",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Festus Yeboah<festus.yeboah@hotmail.com>",
   "license": "MIT",
   "private": false,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "files": [
     "dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
     // in test files for vi to be available
     "types": [
       "vitest/globals"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,5 +12,5 @@ export default defineConfig({
       fileName: "index",
     },
   },
-  plugins: [dts({ insertTypesEntry: true, outDir: "dist", tsconfigPath: './tsconfig.json' })], // also specify for dts plugin
+  plugins: [dts({ insertTypesEntry: true, outDir: "dist", tsconfigPath: './tsconfig.json', rollupTypes: true })], // also specify for dts plugin
 });


### PR DESCRIPTION
This commit aims to resolve issues with type inference and autocompletion in consuming projects by enabling the `rollupTypes: true` option in `vite-plugin-dts`.

Changes:
- Updated `vite.config.ts`:
    - Set `rollupTypes: true` for the `vite-plugin-dts` plugin. This bundles all type declarations into a single `index.d.ts` file, which can improve type resolution for consumers.
- Modified `tsconfig.json`:
    - Removed `noUncheckedSideEffectImports` from `compilerOptions` as it was incompatible with `api-extractor` used by `vite-plugin-dts` when `rollupTypes` is enabled. This change was necessary for the build to succeed with the new dts plugin options.
- Package version updated to `0.4.1`.

These changes should ensure that the published package provides a more robust and complete set of type definitions, addressing problems where properties or methods on imported classes were not being correctly recognized.