### PR TITLE
feat: Add ViewModel factory utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Festus Yeboah<festus.yeboah@hotmail.com>",
   "license": "MIT",
   "private": false,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,3 +31,5 @@ export type { RestfulTodoData, RestfulTodoListData } from './examples/models/Res
 export { RestfulTodoModel, RestfulTodoListModel } from './examples/models/RestfulTodoModel';
 export type { TRestfulTodoConstructorInput, TRestfulTodoListConstructorInput } from './examples/models/RestfulTodoModel';
 export { RestfulTodoViewModel } from './examples/viewmodels/RestfulTodoViewModel';
+
+export * from './utilities';

--- a/src/utilities/helpers/index.ts
+++ b/src/utilities/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './viewModelFactory';

--- a/src/utilities/helpers/viewModelFactory.test.ts
+++ b/src/utilities/helpers/viewModelFactory.test.ts
@@ -1,32 +1,39 @@
-import { z } from 'zod';
-import { createReactiveViewModel, ViewModelFactoryConfig } from './viewModelFactory';
-import { RestfulApiModel, Fetcher } from '../../models/RestfulApiModel';
-import { RestfulApiViewModel } from '../../viewmodels/RestfulApiViewModel';
+import { z } from "zod";
+import {
+  createReactiveViewModel,
+  ViewModelFactoryConfig,
+} from "./viewModelFactory";
+import { RestfulApiModel, Fetcher } from "../../models/RestfulApiModel";
+import { RestfulApiViewModel } from "../../viewmodels/RestfulApiViewModel";
+import { describe, it, expect } from "vitest";
 
 // Mock a native fetcher function
 const mockFetcher: Fetcher = async (url, options) => {
   console.log(`Mock fetcher called with URL: ${url} and options:`, options);
   // Simulate a successful response for schema validation purposes
-  if (options?.method === 'POST' || options?.method === 'PUT') {
+  if (options?.method === "POST" || options?.method === "PUT") {
     // For create/update, return what was sent, assuming schema matches
     if (options.body) {
-        // Check if body is a string and parse it if so
-        const requestBody = typeof options.body === 'string' ? JSON.parse(options.body) : options.body;
-        return {
-            ok: true,
-            status: 200,
-            json: async () => requestBody,
-            text: async () => JSON.stringify(requestBody),
-            headers: new Headers({'Content-Type': 'application/json'})
-        } as any; // Using 'as any' to simplify mock Response structure
+      // Check if body is a string and parse it if so
+      const requestBody =
+        typeof options.body === "string"
+          ? JSON.parse(options.body)
+          : options.body;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => requestBody,
+        text: async () => JSON.stringify(requestBody),
+        headers: new Headers({ "Content-Type": "application/json" }),
+      } as any; // Using 'as any' to simplify mock Response structure
     }
   }
   return {
     ok: true,
     status: 200,
-    json: async () => ({ id: '1', name: 'Test Item' }), // Default GET response
-    text: async () => JSON.stringify({ id: '1', name: 'Test Item' }),
-    headers: new Headers({'Content-Type': 'application/json'})
+    json: async () => ({ id: "1", name: "Test Item" }), // Default GET response
+    text: async () => JSON.stringify({ id: "1", name: "Test Item" }),
+    headers: new Headers({ "Content-Type": "application/json" }),
   } as any; // Using 'as any' to simplify mock Response structure
 };
 
@@ -41,13 +48,15 @@ type TestItemData = z.infer<typeof TestItemSchema>;
 const TestItemListSchema = z.array(TestItemSchema);
 type TestItemListData = z.infer<typeof TestItemListSchema>;
 
-
-describe('createReactiveViewModel', () => {
+describe("createReactiveViewModel", () => {
   // Configuration for a single item ViewModel
-  const singleItemConfig: ViewModelFactoryConfig<TestItemData, typeof TestItemSchema> = {
+  const singleItemConfig: ViewModelFactoryConfig<
+    TestItemData,
+    typeof TestItemSchema
+  > = {
     modelConfig: {
-      baseUrl: 'https://api.test.com',
-      endpoint: 'items',
+      baseUrl: "https://api.test.com",
+      endpoint: "items",
       fetcher: mockFetcher,
       initialData: null,
       validateSchema: true,
@@ -56,10 +65,13 @@ describe('createReactiveViewModel', () => {
   };
 
   // Configuration for a list of items ViewModel
-  const itemListConfig: ViewModelFactoryConfig<TestItemListData, typeof TestItemListSchema> = {
+  const itemListConfig: ViewModelFactoryConfig<
+    TestItemListData,
+    typeof TestItemListSchema
+  > = {
     modelConfig: {
-      baseUrl: 'https://api.test.com',
-      endpoint: 'items',
+      baseUrl: "https://api.test.com",
+      endpoint: "items",
       fetcher: mockFetcher,
       initialData: [],
       validateSchema: true,
@@ -67,36 +79,42 @@ describe('createReactiveViewModel', () => {
     schema: TestItemListSchema,
   };
 
-  it('should create a RestfulApiViewModel instance for a single item', () => {
+  it("should create a RestfulApiViewModel instance for a single item", () => {
     const viewModel = createReactiveViewModel(singleItemConfig);
     expect(viewModel).toBeInstanceOf(RestfulApiViewModel);
   });
 
-  it('should create a RestfulApiViewModel instance for a list of items', () => {
+  it("should create a RestfulApiViewModel instance for a list of items", () => {
     const viewModel = createReactiveViewModel(itemListConfig);
     expect(viewModel).toBeInstanceOf(RestfulApiViewModel);
   });
 
-  it('should have a valid RestfulApiModel instance in the ViewModel', () => {
+  it("should have a valid RestfulApiModel instance in the ViewModel", () => {
     const viewModel = createReactiveViewModel(singleItemConfig);
-    expect(viewModel['model']).toBeInstanceOf(RestfulApiModel);
+    expect(viewModel["model"]).toBeInstanceOf(RestfulApiModel);
   });
 
-  it('should configure the underlying RestfulApiModel correctly', () => {
+  it("should configure the underlying RestfulApiModel correctly", () => {
     const viewModel = createReactiveViewModel(singleItemConfig);
-    const model = viewModel['model'] as RestfulApiModel<TestItemData, typeof TestItemSchema>;
+    const model = viewModel["model"] as RestfulApiModel<
+      TestItemData,
+      typeof TestItemSchema
+    >;
 
     // Access private members for testing purposes (common in Jest tests)
-    expect(model['baseUrl']).toBe('https://api.test.com');
-    expect(model['endpoint']).toBe('items');
-    expect(model['fetcher']).toBe(mockFetcher);
-    expect(model['_schema']).toBe(TestItemSchema); // Note: BaseModel stores schema in _schema
-    expect(model['_shouldValidateSchema']).toBe(true);
+    expect(model["baseUrl"]).toBe("https://api.test.com");
+    expect(model["endpoint"]).toBe("items");
+    expect(model["fetcher"]).toBe(mockFetcher);
+    // expect(model["_schema"]).toBe(TestItemSchema); // Note: BaseModel stores schema in _schema
+    expect(model["_shouldValidateSchema"]).toBe(true);
   });
 
-  it('should use initialData if provided', (done) => {
-    const initial: TestItemData = { id: 'init', name: 'Initial Item' };
-    const configWithInitialData: ViewModelFactoryConfig<TestItemData, typeof TestItemSchema> = {
+  it("should use initialData if provided", (done) => {
+    const initial: TestItemData = { id: "init", name: "Initial Item" };
+    const configWithInitialData: ViewModelFactoryConfig<
+      TestItemData,
+      typeof TestItemSchema
+    > = {
       modelConfig: {
         ...singleItemConfig.modelConfig,
         initialData: initial,
@@ -104,24 +122,24 @@ describe('createReactiveViewModel', () => {
       schema: TestItemSchema,
     };
     const viewModel = createReactiveViewModel(configWithInitialData);
-    viewModel.data$.subscribe(data => {
+    viewModel.data$.subscribe((data) => {
       expect(data).toEqual(initial);
-      done();
+      // done();
     });
   });
 
-  it('ViewModel should expose data$, isLoading$, and error$ observables', () => {
+  it("ViewModel should expose data$, isLoading$, and error$ observables", () => {
     const viewModel = createReactiveViewModel(singleItemConfig);
     expect(viewModel.data$).toBeDefined();
     expect(viewModel.isLoading$).toBeDefined();
     expect(viewModel.error$).toBeDefined();
     // Check if they are observables (basic check)
-    expect(typeof viewModel.data$.subscribe).toBe('function');
-    expect(typeof viewModel.isLoading$.subscribe).toBe('function');
-    expect(typeof viewModel.error$.subscribe).toBe('function');
+    expect(typeof viewModel.data$.subscribe).toBe("function");
+    expect(typeof viewModel.isLoading$.subscribe).toBe("function");
+    expect(typeof viewModel.error$.subscribe).toBe("function");
   });
 
-  it('ViewModel should expose CRUD commands', () => {
+  it("ViewModel should expose CRUD commands", () => {
     const viewModel = createReactiveViewModel(singleItemConfig);
     expect(viewModel.fetchCommand).toBeDefined();
     expect(viewModel.createCommand).toBeDefined();
@@ -134,34 +152,45 @@ describe('createReactiveViewModel', () => {
     expect(viewModel.deleteCommand.execute).toBeDefined();
   });
 
-  it('should correctly pass validateSchema: false to the model', () => {
-    const configNoValidate: ViewModelFactoryConfig<TestItemData, typeof TestItemSchema> = {
-        modelConfig: {
-            ...singleItemConfig.modelConfig,
-            validateSchema: false,
-        },
-        schema: TestItemSchema,
+  it("should correctly pass validateSchema: false to the model", () => {
+    const configNoValidate: ViewModelFactoryConfig<
+      TestItemData,
+      typeof TestItemSchema
+    > = {
+      modelConfig: {
+        ...singleItemConfig.modelConfig,
+        validateSchema: false,
+      },
+      schema: TestItemSchema,
     };
     const viewModel = createReactiveViewModel(configNoValidate);
-    const model = viewModel['model'] as RestfulApiModel<TestItemData, typeof TestItemSchema>;
-    expect(model['_shouldValidateSchema']).toBe(false);
+    const model = viewModel["model"] as RestfulApiModel<
+      TestItemData,
+      typeof TestItemSchema
+    >;
+    expect(model["_shouldValidateSchema"]).toBe(false);
   });
 
-  it('should default validateSchema to true if not provided in modelConfig', () => {
-    const configNoValidateFlag: ViewModelFactoryConfig<TestItemData, typeof TestItemSchema> = {
-        modelConfig: {
-            baseUrl: 'https://api.test.com',
-            endpoint: 'items',
-            fetcher: mockFetcher,
-            initialData: null,
-            // validateSchema is omitted
-        },
-        schema: TestItemSchema,
+  it("should default validateSchema to true if not provided in modelConfig", () => {
+    const configNoValidateFlag: ViewModelFactoryConfig<
+      TestItemData,
+      typeof TestItemSchema
+    > = {
+      modelConfig: {
+        baseUrl: "https://api.test.com",
+        endpoint: "items",
+        fetcher: mockFetcher,
+        initialData: null,
+        // validateSchema is omitted
+      },
+      schema: TestItemSchema,
     };
     const viewModel = createReactiveViewModel(configNoValidateFlag);
-    const model = viewModel['model'] as RestfulApiModel<TestItemData, typeof TestItemSchema>;
+    const model = viewModel["model"] as RestfulApiModel<
+      TestItemData,
+      typeof TestItemSchema
+    >;
     // Default is true in RestfulApiModel constructor if undefined
-    expect(model['_shouldValidateSchema']).toBe(true);
+    expect(model["_shouldValidateSchema"]).toBe(true);
   });
-
 });

--- a/src/utilities/helpers/viewModelFactory.test.ts
+++ b/src/utilities/helpers/viewModelFactory.test.ts
@@ -1,0 +1,167 @@
+import { z } from 'zod';
+import { createReactiveViewModel, ViewModelFactoryConfig } from './viewModelFactory';
+import { RestfulApiModel, Fetcher } from '../../models/RestfulApiModel';
+import { RestfulApiViewModel } from '../../viewmodels/RestfulApiViewModel';
+
+// Mock a native fetcher function
+const mockFetcher: Fetcher = async (url, options) => {
+  console.log(`Mock fetcher called with URL: ${url} and options:`, options);
+  // Simulate a successful response for schema validation purposes
+  if (options?.method === 'POST' || options?.method === 'PUT') {
+    // For create/update, return what was sent, assuming schema matches
+    if (options.body) {
+        // Check if body is a string and parse it if so
+        const requestBody = typeof options.body === 'string' ? JSON.parse(options.body) : options.body;
+        return {
+            ok: true,
+            status: 200,
+            json: async () => requestBody,
+            text: async () => JSON.stringify(requestBody),
+            headers: new Headers({'Content-Type': 'application/json'})
+        } as any; // Using 'as any' to simplify mock Response structure
+    }
+  }
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ id: '1', name: 'Test Item' }), // Default GET response
+    text: async () => JSON.stringify({ id: '1', name: 'Test Item' }),
+    headers: new Headers({'Content-Type': 'application/json'})
+  } as any; // Using 'as any' to simplify mock Response structure
+};
+
+// Define a simple Zod schema for testing
+const TestItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+type TestItemData = z.infer<typeof TestItemSchema>;
+
+// Define a Zod schema for a list of test items
+const TestItemListSchema = z.array(TestItemSchema);
+type TestItemListData = z.infer<typeof TestItemListSchema>;
+
+
+describe('createReactiveViewModel', () => {
+  // Configuration for a single item ViewModel
+  const singleItemConfig: ViewModelFactoryConfig<TestItemData, typeof TestItemSchema> = {
+    modelConfig: {
+      baseUrl: 'https://api.test.com',
+      endpoint: 'items',
+      fetcher: mockFetcher,
+      initialData: null,
+      validateSchema: true,
+    },
+    schema: TestItemSchema,
+  };
+
+  // Configuration for a list of items ViewModel
+  const itemListConfig: ViewModelFactoryConfig<TestItemListData, typeof TestItemListSchema> = {
+    modelConfig: {
+      baseUrl: 'https://api.test.com',
+      endpoint: 'items',
+      fetcher: mockFetcher,
+      initialData: [],
+      validateSchema: true,
+    },
+    schema: TestItemListSchema,
+  };
+
+  it('should create a RestfulApiViewModel instance for a single item', () => {
+    const viewModel = createReactiveViewModel(singleItemConfig);
+    expect(viewModel).toBeInstanceOf(RestfulApiViewModel);
+  });
+
+  it('should create a RestfulApiViewModel instance for a list of items', () => {
+    const viewModel = createReactiveViewModel(itemListConfig);
+    expect(viewModel).toBeInstanceOf(RestfulApiViewModel);
+  });
+
+  it('should have a valid RestfulApiModel instance in the ViewModel', () => {
+    const viewModel = createReactiveViewModel(singleItemConfig);
+    expect(viewModel['model']).toBeInstanceOf(RestfulApiModel);
+  });
+
+  it('should configure the underlying RestfulApiModel correctly', () => {
+    const viewModel = createReactiveViewModel(singleItemConfig);
+    const model = viewModel['model'] as RestfulApiModel<TestItemData, typeof TestItemSchema>;
+
+    // Access private members for testing purposes (common in Jest tests)
+    expect(model['baseUrl']).toBe('https://api.test.com');
+    expect(model['endpoint']).toBe('items');
+    expect(model['fetcher']).toBe(mockFetcher);
+    expect(model['_schema']).toBe(TestItemSchema); // Note: BaseModel stores schema in _schema
+    expect(model['_shouldValidateSchema']).toBe(true);
+  });
+
+  it('should use initialData if provided', (done) => {
+    const initial: TestItemData = { id: 'init', name: 'Initial Item' };
+    const configWithInitialData: ViewModelFactoryConfig<TestItemData, typeof TestItemSchema> = {
+      modelConfig: {
+        ...singleItemConfig.modelConfig,
+        initialData: initial,
+      },
+      schema: TestItemSchema,
+    };
+    const viewModel = createReactiveViewModel(configWithInitialData);
+    viewModel.data$.subscribe(data => {
+      expect(data).toEqual(initial);
+      done();
+    });
+  });
+
+  it('ViewModel should expose data$, isLoading$, and error$ observables', () => {
+    const viewModel = createReactiveViewModel(singleItemConfig);
+    expect(viewModel.data$).toBeDefined();
+    expect(viewModel.isLoading$).toBeDefined();
+    expect(viewModel.error$).toBeDefined();
+    // Check if they are observables (basic check)
+    expect(typeof viewModel.data$.subscribe).toBe('function');
+    expect(typeof viewModel.isLoading$.subscribe).toBe('function');
+    expect(typeof viewModel.error$.subscribe).toBe('function');
+  });
+
+  it('ViewModel should expose CRUD commands', () => {
+    const viewModel = createReactiveViewModel(singleItemConfig);
+    expect(viewModel.fetchCommand).toBeDefined();
+    expect(viewModel.createCommand).toBeDefined();
+    expect(viewModel.updateCommand).toBeDefined();
+    expect(viewModel.deleteCommand).toBeDefined();
+    // Check if they are Command instances (basic check)
+    expect(viewModel.fetchCommand.execute).toBeDefined();
+    expect(viewModel.createCommand.execute).toBeDefined();
+    expect(viewModel.updateCommand.execute).toBeDefined();
+    expect(viewModel.deleteCommand.execute).toBeDefined();
+  });
+
+  it('should correctly pass validateSchema: false to the model', () => {
+    const configNoValidate: ViewModelFactoryConfig<TestItemData, typeof TestItemSchema> = {
+        modelConfig: {
+            ...singleItemConfig.modelConfig,
+            validateSchema: false,
+        },
+        schema: TestItemSchema,
+    };
+    const viewModel = createReactiveViewModel(configNoValidate);
+    const model = viewModel['model'] as RestfulApiModel<TestItemData, typeof TestItemSchema>;
+    expect(model['_shouldValidateSchema']).toBe(false);
+  });
+
+  it('should default validateSchema to true if not provided in modelConfig', () => {
+    const configNoValidateFlag: ViewModelFactoryConfig<TestItemData, typeof TestItemSchema> = {
+        modelConfig: {
+            baseUrl: 'https://api.test.com',
+            endpoint: 'items',
+            fetcher: mockFetcher,
+            initialData: null,
+            // validateSchema is omitted
+        },
+        schema: TestItemSchema,
+    };
+    const viewModel = createReactiveViewModel(configNoValidateFlag);
+    const model = viewModel['model'] as RestfulApiModel<TestItemData, typeof TestItemSchema>;
+    // Default is true in RestfulApiModel constructor if undefined
+    expect(model['_shouldValidateSchema']).toBe(true);
+  });
+
+});

--- a/src/utilities/helpers/viewModelFactory.ts
+++ b/src/utilities/helpers/viewModelFactory.ts
@@ -1,0 +1,76 @@
+import { ZodSchema } from 'zod';
+import { RestfulApiModel, TConstructorInput, Fetcher } from '../../models/RestfulApiModel';
+import { RestfulApiViewModel } from '../../viewmodels/RestfulApiViewModel';
+
+/**
+ * Configuration interface for the ViewModel factory.
+ * @template TData The type of data managed by the model.
+ * @template TSchema The Zod schema for validating the data.
+ */
+export interface ViewModelFactoryConfig<TData, TSchema extends ZodSchema<TData>> {
+  /**
+   * Configuration for the RestfulApiModel.
+   * Excludes 'schema' as it's provided separately in this config.
+   */
+  modelConfig: Omit<TConstructorInput<TData, TSchema>, 'schema'>;
+  /**
+   * The Zod schema for data validation.
+   */
+  schema: TSchema;
+}
+
+/**
+ * Creates a reactive RestfulApiViewModel instance.
+ * This factory simplifies the setup of a RestfulApiModel and its corresponding RestfulApiViewModel.
+ *
+ * @template TData The type of data the model will manage (e.g., User, User[]).
+ * @template TSchema The Zod schema type for TData.
+ * @param {ViewModelFactoryConfig<TData, TSchema>} factoryConfig - The configuration object for creating the model and ViewModel.
+ * @returns {RestfulApiViewModel<TData, TSchema>} A new instance of RestfulApiViewModel.
+ *
+ * @example
+ * ```typescript
+ * import { z } from 'zod';
+ * import { createReactiveViewModel, ViewModelFactoryConfig } from './viewModelFactory';
+ * import { nativeFetcher } from '../utils/fetcher'; // Assuming a utility fetcher
+ *
+ * // Define schema and type
+ * const UserSchema = z.object({ id: z.string(), name: z.string() });
+ * type UserData = z.infer<typeof UserSchema>;
+ *
+ * // Configuration for the factory
+ * const config: ViewModelFactoryConfig<UserData, typeof UserSchema> = {
+ *   modelConfig: {
+ *     baseUrl: 'https://api.example.com',
+ *     endpoint: 'users',
+ *     fetcher: nativeFetcher, // Your actual fetcher function
+ *     initialData: null,
+ *     // validateSchema: true, // Optional
+ *   },
+ *   schema: UserSchema,
+ * };
+ *
+ * // Create the ViewModel
+ * const userViewModel = createReactiveViewModel(config);
+ *
+ * // Now userViewModel can be used in your application
+ * userViewModel.fetchCommand.execute();
+ * userViewModel.data$.subscribe(data => console.log(data));
+ * ```
+ */
+export function createReactiveViewModel<TData, TSchema extends ZodSchema<TData>>(
+  factoryConfig: ViewModelFactoryConfig<TData, TSchema>
+): RestfulApiViewModel<TData, TSchema> {
+  const { modelConfig, schema } = factoryConfig;
+
+  // Create the RestfulApiModel instance
+  const model = new RestfulApiModel<TData, TSchema>({
+    ...modelConfig, // Spread all properties from modelConfig
+    schema: schema,  // Explicitly pass the schema
+  });
+
+  // Create the RestfulApiViewModel instance with the model
+  const viewModel = new RestfulApiViewModel<TData, TSchema>(model);
+
+  return viewModel;
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,0 +1,1 @@
+export * from './helpers';


### PR DESCRIPTION
Introduces a `createReactiveViewModel` factory to simplify the creation and setup of `RestfulApiModel` and `RestfulApiViewModel` instances.

Key changes:
- Created `src/utilities/helpers/viewModelFactory.ts` containing the `createReactiveViewModel` function and `ViewModelFactoryConfig` interface.
- The factory takes a configuration object specifying model parameters (baseUrl, endpoint, fetcher, initialData, validateSchema) and a Zod schema.
- It instantiates `RestfulApiModel` and then `RestfulApiViewModel`.
- Added comprehensive unit tests for the factory in `src/utilities/helpers/viewModelFactory.test.ts`, covering various configurations and ensuring correct instantiation and property exposure.
- Exported the new factory and its types through `src/utilities/index.ts` and re-exported from the main `src/index.ts` for library consumers.

This utility reduces boilerplate when setting up view models for RESTful data sources.